### PR TITLE
32. Render tracks as polylines with circle markers

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { Card, ConfigProvider, Flex, Splitter, Typography } from 'antd';
-import { PathOptions, StyleFunction, CircleMarker } from 'leaflet'
+import { PathOptions, StyleFunction, CircleMarker, Polyline } from 'leaflet'
 import './App.css'
 import { MapContainer, Marker, Popup, TileLayer, GeoJSON, LayerGroup, LayersControl } from 'react-leaflet'
 import initialData from './data/collection.ts'
@@ -67,11 +67,21 @@ function App() {
   useEffect(() => {
     if (store) {
       // find tracks
-      setTracks(store.features.filter((feature) => feature.properties?.dataType === TRACK_TYPE).map((feature, index) => 
-        <LayersControl.Overlay checked={getVisible(feature)} name={`Track-${index}`}>
-          <GeoJSON key={`track-${index}`} data={feature} style={setColor} />
-        </LayersControl.Overlay>  
-      ))
+      setTracks(store.features.filter((feature) => feature.properties?.dataType === TRACK_TYPE).map((feature, index) => {
+        const coordinates = feature.geometry.coordinates as [number, number][];
+        const polyline = <Polyline key={`track-${index}`} positions={coordinates} pathOptions={setColor(feature)} />;
+        const circleMarkers = coordinates.map((coord, i) => (
+          <CircleMarker key={`track-${index}-point-${i}`} center={coord} radius={5} pathOptions={setColor(feature)} />
+        ));
+        return (
+          <LayersControl.Overlay checked={getVisible(feature)} name={`Track-${index}`}>
+            <React.Fragment>
+              {polyline}
+              {circleMarkers}
+            </React.Fragment>
+          </LayersControl.Overlay>
+        );
+      }));
 
       // find zones
       setZones(store.features.filter((feature) => feature.properties?.dataType === ZONE_TYPE).map((feature, index) => 


### PR DESCRIPTION
Fixes #32

Update `src/App.tsx` to render tracks as PolyLine with CircleMarker elements.

* Import `Polyline` from `leaflet`.
* Modify `useEffect` to create PolyLine for track features.
* Add CircleMarker elements for each point in the track.
* Update `tracks` state to include PolyLine and CircleMarker components.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/debrief/reactol/pull/33?shareId=2d9dc108-c223-475c-b8e2-5ab44e593fbf).