### PR TITLE
58. Modify selectionSlice to allow multiple items to be selected

### DIFF
--- a/src/components/Layers.tsx
+++ b/src/components/Layers.tsx
@@ -73,7 +73,7 @@ const Layers: React.FC = () => {
   }
   
   const onSelect: TreeProps['onSelect'] = (selectedKeys) => {
-    const payload: SelectionState = {selected: selectedKeys[0] as string}
+    const payload: SelectionState = {selected: selectedKeys as string[]}
     dispatch({type: 'selection/selectionChanged', payload})
   };
   

--- a/src/components/Layers.tsx
+++ b/src/components/Layers.tsx
@@ -74,8 +74,6 @@ const Layers: React.FC = () => {
   }
   
   const onSelect: TreeProps['onSelect'] = (selectedKeys) => {
-    console.log('layers clicked', selectedKeys)
-
     const payload: SelectionState = {selected: selectedKeys as string[]}
     dispatch({type: 'selection/selectionChanged', payload})
   };
@@ -89,6 +87,7 @@ const Layers: React.FC = () => {
     defaultExpandedKeys={[]}
     defaultSelectedKeys={[]}
     defaultCheckedKeys={[]}
+    multiple={true}
     onSelect={onSelect}
     onCheck={onCheck}
     checkedKeys={checkedKeys}

--- a/src/components/Layers.tsx
+++ b/src/components/Layers.tsx
@@ -9,6 +9,7 @@ import { SelectionState } from '../features/selection/selectionSlice';
 
 const Layers: React.FC = () => {
   const features = useAppSelector(state => state.featureCollection.features)
+  const selectedFeatureIds = useAppSelector(state => state.selected.selected)
   const dispatch = useAppDispatch()
 
   const [model, setModel] = React.useState<TreeDataNode[]>([])
@@ -91,6 +92,7 @@ const Layers: React.FC = () => {
     onSelect={onSelect}
     onCheck={onCheck}
     checkedKeys={checkedKeys}
+    selectedKeys={selectedFeatureIds || []}
     treeData={model} />
 }
 

--- a/src/components/Layers.tsx
+++ b/src/components/Layers.tsx
@@ -73,6 +73,8 @@ const Layers: React.FC = () => {
   }
   
   const onSelect: TreeProps['onSelect'] = (selectedKeys) => {
+    console.log('layers clicked', selectedKeys)
+
     const payload: SelectionState = {selected: selectedKeys as string[]}
     dispatch({type: 'selection/selectionChanged', payload})
   };

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -81,9 +81,12 @@ const Map: React.FC = () => {
   }
 
   const onTooltipClick = (event: LeafletMouseEvent) => {
+    console.log('tooltip click', event);
     if (event.target.feature) {
       const featureId = event.target.feature.id;
-      dispatch({ type: 'selection/selectionChanged', payload: { selected: [featureId] } });  
+      const isSelected = selectedFeaturesId && selectedFeaturesId.includes(featureId as string);
+      console.log('click', featureId, selectedFeaturesId, isSelected);
+      dispatch({ type: 'selection/selectionChanged', payload: { selected: isSelected ? [] : [featureId] } });  
     }
   };
 

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -83,7 +83,7 @@ const Map: React.FC = () => {
   const onTooltipClick = (event: LeafletMouseEvent) => {
     if (event.target.feature) {
       const featureId = event.target.feature.id;
-      dispatch({ type: 'selection/selectionChanged', payload: { selected: featureId } });  
+      dispatch({ type: 'selection/selectionChanged', payload: { selected: [featureId] } });  
     }
   };
 

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -81,11 +81,9 @@ const Map: React.FC = () => {
   }
 
   const onTooltipClick = (event: LeafletMouseEvent) => {
-    console.log('tooltip click', event);
     if (event.target.feature) {
       const featureId = event.target.feature.id;
       const isSelected = selectedFeaturesId && selectedFeaturesId.includes(featureId as string);
-      console.log('click', featureId, selectedFeaturesId, isSelected);
       dispatch({ type: 'selection/selectionChanged', payload: { selected: isSelected ? [] : [featureId] } });  
     }
   };

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -47,7 +47,7 @@ const calcInterpLocation = (poly: MultiPoint, times: any, current: number, index
 
 const Map: React.FC = () => {
   const features = useAppSelector(state => state.featureCollection.features)
-  const selectedFeatureId = useAppSelector(state => state.selected.selected)
+  const selectedFeaturesId = useAppSelector(state => state.selected.selected)
   const {current} = useAppSelector(state => state.time)
   const dispatch = useAppDispatch();
 
@@ -58,14 +58,14 @@ const Map: React.FC = () => {
       if (feat?.properties?.color) {
         res.color = feat.properties.color
       }
-      if(feature.id === selectedFeatureId) {
+      if(selectedFeaturesId && selectedFeaturesId.includes(feature.id as string)) {
         res.color = '#aaa'
       }
     }
     res.weight = 3
     return res;
   };
- 
+
   const InterpolatedLocationMarker = (feature: Feature, ctr: number, current: number): React.ReactElement => {
     if (feature.properties?.times) {
       const times = feature.properties.times

--- a/src/components/Properties.tsx
+++ b/src/components/Properties.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Table, Tooltip } from 'antd';
 import { useAppSelector } from '../app/hooks';
-import { selectedFeatureSelection } from '../features/selection/selectionSlice';
+import { selectedFeaturesSelection } from '../features/selection/selectionSlice';
 import './Properties.css';
 
 const formatItem = (value: any) => {
@@ -23,7 +23,7 @@ const formatItem = (value: any) => {
 }
 
 const Properties: React.FC = () => {
-  const features = useAppSelector(selectedFeatureSelection);
+  const features = useAppSelector(selectedFeaturesSelection);
   if (!features || features.length !== 1) {
     return <div>No feature selected</div>;
   }

--- a/src/components/Properties.tsx
+++ b/src/components/Properties.tsx
@@ -23,12 +23,12 @@ const formatItem = (value: any) => {
 }
 
 const Properties: React.FC = () => {
-  const feature = useAppSelector(selectedFeatureSelection);
-  if (!feature) {
+  const features = useAppSelector(selectedFeatureSelection);
+  if (!features || features.length > 1) {
     return <div>No feature selected</div>;
   }
   
-  const dataSource = Object.entries(feature.properties || {}).map(([key, value], index) => {
+  const dataSource = Object.entries(features[0].properties || {}).map(([key, value], index) => {
     return {
       key: index,
       property: key,

--- a/src/components/Properties.tsx
+++ b/src/components/Properties.tsx
@@ -24,7 +24,7 @@ const formatItem = (value: any) => {
 
 const Properties: React.FC = () => {
   const features = useAppSelector(selectedFeatureSelection);
-  if (!features || features.length > 1) {
+  if (!features || features.length !== 1) {
     return <div>No feature selected</div>;
   }
   

--- a/src/components/Track.tsx
+++ b/src/components/Track.tsx
@@ -16,8 +16,8 @@ interface CoordInstance {
 }
 
 const Track: React.FC<TrackProps> = ({feature}) => {
-  const selectedFeatureId = useAppSelector(state => state.selected.selected)
-  const isSelected = feature.id === selectedFeatureId
+  const selectedFeaturesId = useAppSelector(state => state.selected.selected)
+  const isSelected = selectedFeaturesId && selectedFeaturesId.includes(feature.id as string)
   const {limits} = useAppSelector(state => state.time)
   const dispatch = useAppDispatch()
 

--- a/src/components/Track.tsx
+++ b/src/components/Track.tsx
@@ -61,7 +61,7 @@ const Track: React.FC<TrackProps> = ({feature}) => {
   }, [feature, limits])
 
   const onclick = () => {
-    const payload: SelectionState = {selected: feature.id as string}
+    const payload: SelectionState = {selected: [feature.id as string]}
     dispatch({type: 'selection/selectionChanged', payload})
   }
 

--- a/src/components/Track.tsx
+++ b/src/components/Track.tsx
@@ -1,13 +1,13 @@
 import { Feature, Geometry, MultiPoint } from "geojson";
-import { LatLngExpression  } from 'leaflet'
+import { LatLngExpression, LeafletMouseEvent  } from 'leaflet'
 import { Polyline, CircleMarker, Tooltip } from 'react-leaflet'
-import { useAppDispatch, useAppSelector } from "../app/hooks";
+import { useAppSelector } from "../app/hooks";
 import { format } from "date-fns";
 import { useMemo } from "react";
-import { SelectionState } from "../features/selection/selectionSlice";
 
 export interface TrackProps {
   feature: Feature 
+  onClickHandler: {(id: string, modifier: boolean): void}
 }
 
 interface CoordInstance {
@@ -15,11 +15,10 @@ interface CoordInstance {
   time: string
 }
 
-const Track: React.FC<TrackProps> = ({feature}) => {
+const Track: React.FC<TrackProps> = ({feature, onClickHandler}) => {
   const selectedFeaturesId = useAppSelector(state => state.selected.selected)
-  const isSelected = selectedFeaturesId && selectedFeaturesId.includes(feature.id as string)
+  const isSelected = selectedFeaturesId.includes(feature.id as string)
   const {limits} = useAppSelector(state => state.time)
-  const dispatch = useAppDispatch()
 
   const colorFor = (feature: Feature<Geometry, unknown> | undefined): string => {
     if (isSelected) {
@@ -60,10 +59,8 @@ const Track: React.FC<TrackProps> = ({feature}) => {
     }
   }, [feature, limits])
 
-  const onclick = () => {
-    console.log('track clicked', feature.id)
-    const payload: SelectionState = {selected: isSelected ? [] : [feature.id as string]}
-    dispatch({type: 'selection/selectionChanged', payload})
+  const onclick = (evt: LeafletMouseEvent) => {
+    onClickHandler(feature.id as string, evt.originalEvent.altKey || evt.originalEvent.ctrlKey)
   }
 
   return (

--- a/src/components/Track.tsx
+++ b/src/components/Track.tsx
@@ -61,7 +61,8 @@ const Track: React.FC<TrackProps> = ({feature}) => {
   }, [feature, limits])
 
   const onclick = () => {
-    const payload: SelectionState = {selected: [feature.id as string]}
+    console.log('track clicked', feature.id)
+    const payload: SelectionState = {selected: isSelected ? [] : [feature.id as string]}
     dispatch({type: 'selection/selectionChanged', payload})
   }
 

--- a/src/components/Zone.tsx
+++ b/src/components/Zone.tsx
@@ -32,7 +32,7 @@ const Zone: React.FC<TrackProps> = ({feature}) => {
   const trackCoords = (feature.geometry as Polygon).coordinates[0].map(item => [item[1], item[0]]) as LatLngExpression[]
 
   const onclick = () => {
-    const payload: SelectionState = {selected: feature.id as string}
+    const payload: SelectionState = {selected: [feature.id as string]}
     dispatch({type: 'selection/selectionChanged', payload})
   }
   return (

--- a/src/components/Zone.tsx
+++ b/src/components/Zone.tsx
@@ -10,9 +10,9 @@ export interface TrackProps {
 }
 
 const Zone: React.FC<TrackProps> = ({feature}) => {
-  const selectedFeatureId = useAppSelector(state => state.selected.selected)
+  const selectedFeaturesId = useAppSelector(state => state.selected.selected)
   const dispatch = useAppDispatch()
-  const isSelected = feature.id === selectedFeatureId
+  const isSelected = selectedFeaturesId && selectedFeaturesId.includes(feature.id as string)
 
   const colorFor = (feature: Feature<Geometry, unknown> | undefined): string => {
     if (isSelected) {

--- a/src/components/Zone.tsx
+++ b/src/components/Zone.tsx
@@ -32,7 +32,9 @@ const Zone: React.FC<TrackProps> = ({feature}) => {
   const trackCoords = (feature.geometry as Polygon).coordinates[0].map(item => [item[1], item[0]]) as LatLngExpression[]
 
   const onclick = () => {
-    const payload: SelectionState = {selected: [feature.id as string]}
+    console.log('zone clicked', feature.id)
+
+    const payload: SelectionState = {selected: isSelected ? [] : [feature.id as string]}
     dispatch({type: 'selection/selectionChanged', payload})
   }
   return (

--- a/src/components/Zone.tsx
+++ b/src/components/Zone.tsx
@@ -1,18 +1,17 @@
 import * as turf from "turf";
 import { Feature, Geometry, Polygon } from "geojson";
-import { LatLngExpression  } from 'leaflet'
+import { LatLngExpression, LeafletMouseEvent  } from 'leaflet'
 import { Polyline as ReactPolygon, Tooltip } from 'react-leaflet'
-import { useAppDispatch, useAppSelector } from "../app/hooks";
-import { SelectionState } from "../features/selection/selectionSlice";
+import { useAppSelector } from "../app/hooks";
 
-export interface TrackProps {
+export interface ZoneProps {
   feature: Feature 
+  onClickHandler: {(id: string, modifier: boolean): void}
 }
 
-const Zone: React.FC<TrackProps> = ({feature}) => {
+const Zone: React.FC<ZoneProps> = ({feature, onClickHandler}) => {
   const selectedFeaturesId = useAppSelector(state => state.selected.selected)
-  const dispatch = useAppDispatch()
-  const isSelected = selectedFeaturesId && selectedFeaturesId.includes(feature.id as string)
+  const isSelected = selectedFeaturesId.includes(feature.id as string)
 
   const colorFor = (feature: Feature<Geometry, unknown> | undefined): string => {
     if (isSelected) {
@@ -31,12 +30,10 @@ const Zone: React.FC<TrackProps> = ({feature}) => {
   const centre = turf.center(points).geometry.coordinates.reverse() as LatLngExpression
   const trackCoords = (feature.geometry as Polygon).coordinates[0].map(item => [item[1], item[0]]) as LatLngExpression[]
 
-  const onclick = () => {
-    console.log('zone clicked', feature.id)
-
-    const payload: SelectionState = {selected: isSelected ? [] : [feature.id as string]}
-    dispatch({type: 'selection/selectionChanged', payload})
+  const onclick = (evt: LeafletMouseEvent) => {
+    onClickHandler(feature.id as string, evt.originalEvent.altKey || evt.originalEvent.ctrlKey)
   }
+
   return (
     <>
       <ReactPolygon key={feature.id + '-line2' + isSelected} fill={true} positions={trackCoords} weight={2} 

--- a/src/features/selection/selectionSlice.ts
+++ b/src/features/selection/selectionSlice.ts
@@ -24,5 +24,5 @@ const selectionSlice = createSlice({
 // Export the generated reducer function
 export default selectionSlice.reducer
 
-export const selectedFeatureSelection = (state: RootState) =>
+export const selectedFeaturesSelection = (state: RootState) =>
   state.featureCollection.features.filter(feature => state.selected.selected?.includes(feature.id as string))

--- a/src/features/selection/selectionSlice.ts
+++ b/src/features/selection/selectionSlice.ts
@@ -2,7 +2,7 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 import { RootState } from '../../app/store'
 
 export interface SelectionState {
-  selected: string | null
+  selected: string[] | null
 }
 
 const initialState: SelectionState = {
@@ -25,4 +25,4 @@ const selectionSlice = createSlice({
 export default selectionSlice.reducer
 
 export const selectedFeatureSelection = (state: RootState) =>
-  state.featureCollection.features.find(feature => feature.id === state.selected.selected)
+  state.featureCollection.features.filter(feature => state.selected.selected?.includes(feature.id as string))

--- a/src/features/selection/selectionSlice.ts
+++ b/src/features/selection/selectionSlice.ts
@@ -2,11 +2,11 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 import { RootState } from '../../app/store'
 
 export interface SelectionState {
-  selected: string[] | null
+  selected: string[]
 }
 
 const initialState: SelectionState = {
-  selected: null
+  selected: []
 }
 
 
@@ -17,6 +17,14 @@ const selectionSlice = createSlice({
   reducers: {
     selectionChanged(_state, action: PayloadAction<SelectionState>) {
       return action.payload
+    },
+    addSelection(state, action: PayloadAction<string>) {
+      const res = {selected: [...state.selected, action.payload]}
+      return res
+    },
+    removeSelection(state, action: PayloadAction<string>) {
+      const res = {selected: state.selected.filter((id) => id !== action.payload)}
+      return res
     }
   }
 })


### PR DESCRIPTION
Fixes #58

Modify `selectionSlice` to allow multiple items to be selected.

* Update `SelectionState` in `src/features/selection/selectionSlice.ts` to allow for an array of selection ids.
* Update `selectionChanged` action in `src/features/selection/selectionSlice.ts` to accept an array of selection ids.
* Update `selectedFeatureSelection` in `src/features/selection/selectionSlice.ts` to handle multiple selection ids.
* Update `onSelect` function in `src/components/Layers.tsx` to dispatch a `selectionChanged` event with an array of items.
* Update `onTooltipClick` function in `src/components/Map.tsx` to dispatch a `selectionChanged` event with an array of items.
* Update `onclick` function in `src/components/Track.tsx` to dispatch a `selectionChanged` event with an array of items.
* Update `onclick` function in `src/components/Zone.tsx` to dispatch a `selectionChanged` event with an array of items.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/debrief/reactol/pull/59?shareId=a0c28a87-afbf-4a42-bb88-2a7071ba2c5d).