### PR TITLE
reinstate selection from single store

### DIFF
--- a/src/components/GraphModal.tsx
+++ b/src/components/GraphModal.tsx
@@ -96,7 +96,6 @@ const GraphView: React.FC<GraphProps> = ({open, doClose}) => {
           const data = calc.calculate(features, baseTrack)
           return data
         })
-        console.log('graph data', graphData)
         const flattened = graphData.flat(1)
         // find earliest and latest date values
         const dates = flattened.map((dataset) => dataset.data.map((datum) => datum.date)).flat(1)

--- a/src/features/selection/selectionSlice.ts
+++ b/src/features/selection/selectionSlice.ts
@@ -1,4 +1,5 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { RootState } from '../../app/store'
 
 export interface SelectionState {
   selected: string[]
@@ -31,3 +32,6 @@ const selectionSlice = createSlice({
 // Export the generated reducer function
 export default selectionSlice.reducer
 
+
+export const selectedFeaturesSelection = (state: RootState) =>
+  state.featureCollection.features.filter(feature => state.selected.selected?.includes(feature.id as string))


### PR DESCRIPTION
The twin store introduced in #67 introduced a runtime error.

Revert.