### PR TITLE
70. Introduce new Store selection for current locations

### DIFF
--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -3,12 +3,14 @@ import { configureStore } from '@reduxjs/toolkit'
 import featuresReducer from '../features/geoFeatures/geoFeaturesSlice'
 import selectionReducer from '../features/selection/selectionSlice'
 import timeReducer from '../features/time/timeSlice'
+import currentLocationReducer from '../features/currentLocation/currentLocationSlice'
 
 export const store = configureStore({
   reducer: {
     featureCollection: featuresReducer,
     selected: selectionReducer,
-    time: timeReducer
+    time: timeReducer,
+    currentLocation: currentLocationReducer
   }
 })
 

--- a/src/features/currentLocation/currentLocationSlice.ts
+++ b/src/features/currentLocation/currentLocationSlice.ts
@@ -1,8 +1,8 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { Feature } from 'geojson';
+import { Feature, Point } from 'geojson';
 
 interface CurrentLocationState {
-  locations: Feature[];
+  locations: Feature<Point>[];
 }
 
 const initialState: CurrentLocationState = {
@@ -13,7 +13,7 @@ const currentLocationSlice = createSlice({
   name: 'currentLocation',
   initialState,
   reducers: {
-    updateLocation(state, action: PayloadAction<Feature[]>) {
+    updateLocation(state, action: PayloadAction<Feature<Point>[]>) {
       state.locations = action.payload;
     }
   }

--- a/src/features/currentLocation/currentLocationSlice.ts
+++ b/src/features/currentLocation/currentLocationSlice.ts
@@ -1,0 +1,23 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { Feature } from 'geojson';
+
+interface CurrentLocationState {
+  locations: Feature[];
+}
+
+const initialState: CurrentLocationState = {
+  locations: []
+};
+
+const currentLocationSlice = createSlice({
+  name: 'currentLocation',
+  initialState,
+  reducers: {
+    updateLocation(state, action: PayloadAction<Feature[]>) {
+      state.locations = action.payload;
+    }
+  }
+});
+
+export const { updateLocation } = currentLocationSlice.actions;
+export default currentLocationSlice.reducer;


### PR DESCRIPTION
Fixes #70

Add a new `CurrentLocation` selector in the AppStore with an `updateLocation` action to monitor current locations of vessels as the time changes.

* **Add `currentLocationSlice.ts`**:
  - Create a new slice for `currentLocation` with an `updateLocation` action.
  - Define the initial state as an empty array of GeoJSON point objects.
  - Add a reducer to handle the `updateLocation` action.

* **Update `store.ts`**:
  - Import the `currentLocation` reducer from `currentLocationSlice.ts`.
  - Add the `currentLocation` reducer to the store configuration.

* **Modify `App.tsx`**:
  - Import the `updateLocation` action from `currentLocationSlice.ts`.
  - Add a `useEffect` to listen for changes in `TimeState` and dispatch `updateLocation`.
  - Retrieve current features, identify tracks, and collate an array of GeoJSON features.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/debrief/reactol/pull/74?shareId=75a941c1-177d-4dd4-8098-c2f8f179d85c).