### PR TITLE
78. Fix layer selection behavior

### DIFF
--- a/src/components/Layers.tsx
+++ b/src/components/Layers.tsx
@@ -79,9 +79,15 @@ const Layers: React.FC<LayerProps> = ({openGraph}) => {
     return ids.filter((id) => !id.startsWith('node-'))
   }
   
-  const onSelect: TreeProps['onSelect'] = (selectedKeys) => {
-    const payload: SelectionState = {selected: selectedKeys as string[]}
-    dispatch({type: 'selection/selectionChanged', payload})
+  const onSelect: TreeProps['onSelect'] = (selectedKeys, { event }) => {
+    const altKey = event?.event?.altKey || false;
+    if (altKey) {
+      const payload: SelectionState = { selected: selectedKeys as string[] };
+      dispatch({ type: 'selection/selectionChanged', payload });
+    } else {
+      const payload: SelectionState = { selected: [selectedKeys[selectedKeys.length - 1]] as string[] };
+      dispatch({ type: 'selection/selectionChanged', payload });
+    }
   };
   
   const onCheck: TreeProps['onCheck'] = (checkedKeys) => {

--- a/src/components/Layers.tsx
+++ b/src/components/Layers.tsx
@@ -1,6 +1,6 @@
 import React, { Key, useEffect } from 'react';
 import { Button, Flex, Tree } from 'antd';
-import type { GetProps, TreeDataNode, TreeProps } from 'antd';
+import type { GetProps, TreeDataNode } from 'antd';
 import './Layers.css';
 import { LineChartOutlined } from '@ant-design/icons';
 import { Feature } from 'geojson'
@@ -83,7 +83,7 @@ const Layers: React.FC<LayerProps> = ({openGraph}) => {
     return ids.filter((id) => !(id as string).startsWith('node-'))
   }
   
-  const onSelect: DirectoryTreeProps['onSelect'] = (selectedKeys, event ) => {
+  const onSelect: DirectoryTreeProps['onSelect'] = (selectedKeys ) => {
     const payload: SelectionState = { selected: justLeaves(selectedKeys) as string[] };
     dispatch({ type: 'selection/selectionChanged', payload });
   };

--- a/src/components/Layers.tsx
+++ b/src/components/Layers.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect } from 'react';
+import React, { Key, useEffect } from 'react';
 import { Button, Flex, Tree } from 'antd';
-import type { TreeDataNode, TreeProps } from 'antd';
+import type { GetProps, TreeDataNode, TreeProps } from 'antd';
 import './Layers.css';
 import { LineChartOutlined } from '@ant-design/icons';
 import { Feature } from 'geojson'
@@ -11,6 +11,10 @@ import { selectedFeaturesSelection, SelectionState } from '../features/selection
 interface LayerProps {
   openGraph: {(): void}
 }
+
+type DirectoryTreeProps = GetProps<typeof Tree.DirectoryTree>;
+
+const { DirectoryTree } = Tree;
 
 const Layers: React.FC<LayerProps> = ({openGraph}) => {
   const features = useAppSelector(state => state.featureCollection.features)
@@ -75,23 +79,17 @@ const Layers: React.FC<LayerProps> = ({openGraph}) => {
   }, [features])
   
   // filter out the branches, just leave the leaves
-  const justLeaves = (ids: string[]): string[] => {
-    return ids.filter((id) => !id.startsWith('node-'))
+  const justLeaves = (ids: Key[]): Key[] => {
+    return ids.filter((id) => !(id as string).startsWith('node-'))
   }
   
-  const onSelect: TreeProps['onSelect'] = (selectedKeys, { event }) => {
-    const altKey = event?.event?.altKey || false;
-    if (altKey) {
-      const payload: SelectionState = { selected: selectedKeys as string[] };
-      dispatch({ type: 'selection/selectionChanged', payload });
-    } else {
-      const payload: SelectionState = { selected: [selectedKeys[selectedKeys.length - 1]] as string[] };
-      dispatch({ type: 'selection/selectionChanged', payload });
-    }
+  const onSelect: DirectoryTreeProps['onSelect'] = (selectedKeys, event ) => {
+    const payload: SelectionState = { selected: justLeaves(selectedKeys) as string[] };
+    dispatch({ type: 'selection/selectionChanged', payload });
   };
   
-  const onCheck: TreeProps['onCheck'] = (checkedKeys) => {
-    const keys = justLeaves(checkedKeys as string[])
+  const onCheck: DirectoryTreeProps['onCheck'] = (checkedKeys) => {
+    const keys = justLeaves(checkedKeys as Key[])
     dispatch({type: 'featureCollection/featuresVisible', payload: {ids: keys}})
   };
 
@@ -107,13 +105,14 @@ const Layers: React.FC<LayerProps> = ({openGraph}) => {
     <Flex gap='small' justify='end' wrap>
       <Button onClick={onGraphClick} disabled={!temporalFeatureSelected()} type="primary"><LineChartOutlined /></Button>
     </Flex>
-    <Tree checkable
+    <DirectoryTree checkable
       defaultExpandedKeys={[]}
       defaultSelectedKeys={[]}
       defaultCheckedKeys={[]}
       multiple={true}
       onSelect={onSelect}
       onCheck={onCheck}
+      showIcon={false}
       checkedKeys={checkedKeys}
       selectedKeys={selectedFeatureIds || []}
       treeData={model} />

--- a/src/components/TimeControl.tsx
+++ b/src/components/TimeControl.tsx
@@ -13,7 +13,7 @@ export interface TimeProps {
   setUpperLimit: (value: number) => void
 }
 
-const steps = 500
+const steps = 100
 
 const scaled = (start: number, end: number, value: number): number => {
   const range = end - start


### PR DESCRIPTION
Fixes #78

Update the `onSelect` function in `src/components/Layers.tsx` to handle selection logic based on the alt key.

* Add a check for the alt key in the `onSelect` function.
* If the alt key is held down, add/remove items from the selected items.
* If the alt key is not held down, set the new item as the selected feature.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/debrief/reactol/pull/79?shareId=81621b99-4271-467d-a488-556666355a62).