### PR TITLE
exclude .vite folder from DVCS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,7 +101,6 @@ dist
 
 # vuepress v2.x temp and cache directory
 .temp
-.cache
 
 # Docusaurus cache and generated files
 .docusaurus
@@ -130,3 +129,4 @@ dist
 
 *storybook.log
 build/
+/.vite/


### PR DESCRIPTION
Running the electron build (or maybe vite) caused lots of artefacts to be generated.

Deliberately exclude them from build process.

@lilitkarapetyan - it is ok to ignore these, isn't it?